### PR TITLE
Add huggingface cache as volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ RUN chmod 755 /bin/startup.sh
 
 VOLUME [ "/deps" ]
 VOLUME [ "/sd-webui" ]
+VOLUME [ "/root/.cache/huggingface" ]
 
 ENV venv_dir=/deps/venv
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,6 +18,7 @@
 > -v /usr/lib/wsl:/usr/lib/wsl `
 > -v $home\docker-mount\sd-webui:/sd-webui `
 > -v deps:/deps `
+> -v huggingface:/root/.cache/huggingface `
 > -p 7860:7860 `
 > --rm `
 > -e http_proxy=<host_ip>:<proxy_port> `
@@ -39,6 +40,7 @@
 > -v /usr/lib/wsl:/usr/lib/wsl `
 > -v $home\docker-mount\sd-webui:/sd-webui `
 > -v deps:/deps `
+> -v huggingface:/root/.cache/huggingface `
 > -p 7860:7860 `
 > --rm `
 > -e PIP_EXTRA_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple `

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,6 +20,7 @@ docker run -it `
 -v /usr/lib/wsl:/usr/lib/wsl `
 -v $home\docker-mount\sd-webui:/sd-webui `
 -v deps:/deps `
+-v huggingface:/root/.cache/huggingface `
 -p 7860:7860 `
 --name sd-server `
 nuullll/ipex-arc-sd:latest
@@ -32,6 +33,7 @@ docker run -it \
 --device /dev/dri \
 -v ~/docker-mount/sd-webui:/sd-webui \
 -v deps:/deps \
+-v huggingface:/root/.cache/huggingface \
 -p 7860:7860 \
 --name sd-server \
 nuullll/ipex-arc-sd:latest
@@ -64,6 +66,7 @@ docker run -it `
 >> -v /usr/lib/wsl:/usr/lib/wsl `
 >> -v $home\docker-mount\sd-webui:/sd-webui `
 >> -v deps:/deps `
+>> -v huggingface:/root/.cache/huggingface `
 >> -p 7860:7860 `
 >> --name sd-server `
 >> nuullll/ipex-arc-sd:latest
@@ -273,6 +276,7 @@ docker run -it `
 -v /usr/lib/wsl:/usr/lib/wsl `
 -v $home\docker-mount\sd-webui:/sd-webui `
 -v deps:/deps `
+-v huggingface:/root/.cache/huggingface `
 -p 7860:7860 `
 --name customized-sd-server `
 nuullll/ipex-arc-sd:latest `
@@ -286,6 +290,7 @@ docker run -it \
 --device /dev/dri \
 -v ~/docker-mount/sd-webui:/sd-webui \
 -v deps:/deps \
+-v huggingface:/root/.cache/huggingface \
 -p 7860:7860 \
 --name customized-sd-server \
 nuullll/ipex-arc-sd:latest \
@@ -310,6 +315,7 @@ docker run -it `
 -v /usr/lib/wsl:/usr/lib/wsl `
 -v $home\docker-mount\sd-webui:/sd-webui `
 -v deps:/deps `
+-v huggingface:/root/.cache/huggingface `
 -p 7860:7860 `
 --rm `
 nuullll/ipex-arc-sd:latest --upgrade
@@ -322,6 +328,7 @@ docker run -it \
 --device /dev/dri \
 -v ~/docker-mount/sd-webui:/sd-webui \
 -v deps:/deps \
+-v huggingface:/root/.cache/huggingface \
 -p 7860:7860 \
 --rm \
 nuullll/ipex-arc-sd:latest --upgrade

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -18,6 +18,7 @@
 > -v /usr/lib/wsl:/usr/lib/wsl `
 > -v $home\docker-mount\sd-webui:/sd-webui `
 > -v deps:/deps `
+> -v huggingface:/root/.cache/huggingface `
 > -p 7860:7860 `
 > --rm `
 > -e http_proxy=<host_ip>:<proxy_port> `
@@ -39,6 +40,7 @@
 > -v /usr/lib/wsl:/usr/lib/wsl `
 > -v $home\docker-mount\sd-webui:/sd-webui `
 > -v deps:/deps `
+> -v huggingface:/root/.cache/huggingface `
 > -p 7860:7860 `
 > --rm `
 > -e PIP_EXTRA_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple `

--- a/docs/zh-cn/getting-started.md
+++ b/docs/zh-cn/getting-started.md
@@ -20,6 +20,7 @@ docker run -it `
 -v /usr/lib/wsl:/usr/lib/wsl `
 -v $home\docker-mount\sd-webui:/sd-webui `
 -v deps:/deps `
+-v huggingface:/root/.cache/huggingface `
 -p 7860:7860 `
 --name sd-server `
 nuullll/ipex-arc-sd:latest
@@ -32,6 +33,7 @@ docker run -it \
 --device /dev/dri \
 -v ~/docker-mount/sd-webui:/sd-webui \
 -v deps:/deps \
+-v huggingface:/root/.cache/huggingface \
 -p 7860:7860 \
 --name sd-server \
 nuullll/ipex-arc-sd:latest
@@ -64,6 +66,7 @@ docker run -it `
 >> -v /usr/lib/wsl:/usr/lib/wsl `
 >> -v $home\docker-mount\sd-webui:/sd-webui `
 >> -v deps:/deps `
+>> -v huggingface:/root/.cache/huggingface `
 >> -p 7860:7860 `
 >> --name sd-server `
 >> nuullll/ipex-arc-sd:latest
@@ -273,6 +276,7 @@ docker run -it `
 -v /usr/lib/wsl:/usr/lib/wsl `
 -v $home\docker-mount\sd-webui:/sd-webui `
 -v deps:/deps `
+-v huggingface:/root/.cache/huggingface `
 -p 7860:7860 `
 --name customized-sd-server `
 nuullll/ipex-arc-sd:latest `
@@ -286,6 +290,7 @@ docker run -it \
 --device /dev/dri \
 -v ~/docker-mount/sd-webui:/sd-webui \
 -v deps:/deps \
+-v huggingface:/root/.cache/huggingface \
 -p 7860:7860 \
 --name customized-sd-server \
 nuullll/ipex-arc-sd:latest \
@@ -310,6 +315,7 @@ docker run -it `
 -v /usr/lib/wsl:/usr/lib/wsl `
 -v $home\docker-mount\sd-webui:/sd-webui `
 -v deps:/deps `
+-v huggingface:/root/.cache/huggingface `
 -p 7860:7860 `
 --rm `
 nuullll/ipex-arc-sd:latest --upgrade
@@ -322,6 +328,7 @@ docker run -it \
 --device /dev/dri \
 -v ~/docker-mount/sd-webui:/sd-webui \
 -v deps:/deps \
+-v huggingface:/root/.cache/huggingface \
 -p 7860:7860 \
 --rm \
 nuullll/ipex-arc-sd:latest --upgrade


### PR DESCRIPTION
SD WebUI downloads the core huggingface models into .cache folder.
Adding this as a volume will prevent re-downloads.